### PR TITLE
fix(backend): GET /advertisement/:id only accept integer id

### DIFF
--- a/backend/internal/controllers/advertisement.go
+++ b/backend/internal/controllers/advertisement.go
@@ -16,9 +16,15 @@ import . "boschXdaimlerLove/MietMiez/internal/logger"
 func AdvertisementInformation(c *fiber.Ctx) error {
 	var advertisement models.Advertisement
 	dbInstance := database.GetDB()
+
+	id, err := strconv.Atoi(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).SendString("id must be an integer")
+	}
+
 	result := dbInstance.
 		Preload("User").
-		First(&advertisement, "id = ?", c.Params("id"))
+		First(&advertisement, "id = ?", id)
 
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return c.SendStatus(fiber.StatusNotFound)

--- a/openapi/mietmiez.yml
+++ b/openapi/mietmiez.yml
@@ -223,6 +223,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Advertisement'
+        '400':
+          description: id was not an integer
         '404':
           description: Advertisement does not exist or was permanently removed
     delete:


### PR DESCRIPTION
more meaningful error (bad request) when given id isn't an integer. Old code (internal server error) was misleading.