### PR TITLE
fix(api): return user token in json

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"github.com/gofiber/fiber/v2/middleware/compress"
 	"github.com/gofiber/fiber/v2/middleware/csrf"
-	"github.com/gofiber/fiber/v2/middleware/encryptcookie"
 	"log/slog"
 	"os"
 	"time"
@@ -27,9 +26,8 @@ type Config struct {
 	Server struct {
 		TokenLength     int
 		SessionDuration time.Duration
-		Port            int    `yaml:"port" envconfig:"BACKEND_PORT"`
-		CookieKey       string `yaml:"cookie_key" envconfig:"BACKEND_COOKIE_KEY"` // MUST BE 32 CHAR STRING!!!!
-		Production      bool   `yaml:"production" envconfig:"BACKEND_PRODUCTION"`
+		Port            int  `yaml:"port" envconfig:"BACKEND_PORT"`
+		Production      bool `yaml:"production" envconfig:"BACKEND_PRODUCTION"`
 	} `yaml:"backend"`
 
 	Database struct {
@@ -84,14 +82,6 @@ func SetupConfig() {
 func GetCompressionConfig() compress.Config {
 	return compress.Config{
 		Level: compress.LevelBestSpeed,
-	}
-}
-
-// GetCookieEncryptionConfig https://docs.gofiber.io/api/middleware/encryptcookie
-func GetCookieEncryptionConfig() encryptcookie.Config {
-	return encryptcookie.Config{
-		Key:    Cfg.Server.CookieKey,                    // MUST BE 32 CHAR STRING
-		Except: []string{csrf.ConfigDefault.CookieName}, // exclude CSRF cookie
 	}
 }
 

--- a/backend/internal/controllers/user.go
+++ b/backend/internal/controllers/user.go
@@ -78,15 +78,10 @@ func UserLogin(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}
 
-	cookie := &fiber.Cookie{
-		Name:    "session",
-		Value:   session.ID,
-		Expires: time.Now().Add(config.Cfg.Server.SessionDuration),
-		Secure:  config.Cfg.Server.Production,
-	}
-
-	c.Cookie(cookie)
-	return c.SendStatus(fiber.StatusOK)
+	return c.Status(fiber.StatusOK).JSON(fiber.Map{
+		"token":      session.ID,
+		"expires_at": time.Now().Add(config.Cfg.Server.SessionDuration),
+	})
 }
 
 func UserDelete(c *fiber.Ctx) error {

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -6,7 +6,6 @@ import (
 	"boschXdaimlerLove/MietMiez/internal/middleware"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/compress"
-	"github.com/gofiber/fiber/v2/middleware/encryptcookie"
 	"github.com/gofiber/fiber/v2/middleware/monitor"
 )
 
@@ -50,9 +49,6 @@ func SetupRoutes(app *fiber.App) {
 
 	// enable compression
 	app.Use(compress.New(config.GetCompressionConfig()))
-
-	// encrypt cookie
-	app.Use(encryptcookie.New(config.GetCookieEncryptionConfig()))
 
 	// set csrf cookie
 	//app.Use(csrf.New(config.GetCSRFConfig()))

--- a/openapi/mietmiez.yml
+++ b/openapi/mietmiez.yml
@@ -471,10 +471,11 @@ components:
       properties:
         token:
           type: string
-          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-        expires_in:
-          type: integer
-          example: 3600
+          # noinspection SpellCheckingInspection
+          example: umxBkyW3P-wHb2AW1L_rmTRIi99S6beIyZnva3N8ZOI=
+        expires_at:
+          type: string
+          example: 2025-07-07T09:23:36.937392461Z
     LoginRequest:
       type: object
       required:


### PR DESCRIPTION
since api is only being accessed by the frontend server, no cookie can be set, instead we return the cookie as json payload for the frontendserver which then sets it as user cookie fix #78