### PR TITLE
fix(frontend): multiple images are now displayed

### DIFF
--- a/frontend/mietmiez/src/app/advertisement/new/NewAdvertisementPage.tsx
+++ b/frontend/mietmiez/src/app/advertisement/new/NewAdvertisementPage.tsx
@@ -41,10 +41,9 @@ export default function NewAdvertisementPage() {
   }, []);
 
   async function handleImageChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
-    if (file) {
-      const newFiles = [...files, file];
-      setFiles(newFiles);
+    const selectedFiles = Array.from(event.target.files || []);
+    if (selectedFiles) {
+      setFiles(selectedFiles);
     }
   }
 
@@ -161,6 +160,7 @@ export default function NewAdvertisementPage() {
           <input
             ref={fileInputRed}
             type="file"
+            multiple
             accept="image/*"
             onChange={handleImageChange}
             className="mt-2 block w-full text-sm text-gray-500


### PR DESCRIPTION
multiple images can now be added and will be displayed as "2 files selected" etc. depending on file count.

HTML input only displays latest selected files, so multiple files have to be select in one dialog call. Multiple dialog calls will replace previous images.
This is the behaviour reflected in the UI.

Better solution could be implemented in the future