### PR TITLE
fix(api): save unique imgs to an advertisement

### DIFF
--- a/backend/internal/controllers/advertisement.go
+++ b/backend/internal/controllers/advertisement.go
@@ -6,8 +6,10 @@ import (
 	"boschXdaimlerLove/MietMiez/internal/util"
 	"errors"
 	"github.com/gofiber/fiber/v2"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+	"slices"
 	"strconv"
 )
 
@@ -49,6 +51,28 @@ func CreateAdvertisement(c *fiber.Ctx) error {
 
 	if err := util.GetJsonFromRequest(c, advertisement); err != nil {
 		return c.SendStatus(fiber.StatusInternalServerError)
+	}
+
+	imgs := advertisement.Images
+	Logger.Info().Any("imgs", imgs).Msg("imgs before sorting")
+
+	if len(imgs) > 0 {
+		slices.Sort(imgs)
+		Logger.Info().Any("imgs", imgs).Msg("imgs after sorting")
+
+		uniqueImgs := make(datatypes.JSONSlice[string], 0, len(imgs))
+		uniqueImgs = append(uniqueImgs, imgs[0])
+
+		for i := 1; i < len(imgs); i++ {
+			if imgs[i] != imgs[i-1] {
+				uniqueImgs = append(uniqueImgs, imgs[i])
+			}
+		}
+
+		advertisement.Images = uniqueImgs
+		Logger.Info().Any("imgs", uniqueImgs).Msg("unique imgs")
+	} else {
+		Logger.Trace().Any("advertisement", advertisement).Msg("No images uploaded with advertisement")
 	}
 
 	dbInstance := database.GetDB()
@@ -112,7 +136,7 @@ func UpdateAdvertisement(c *fiber.Ctx) error {
 
 	return c.SendStatus(fiber.StatusOK)
 }
-  
+
 func GetRecentAdvertisements(c *fiber.Ctx) error {
 	var advertisements models.AdvertisementList
 	dbInstance := database.GetDB()

--- a/backend/internal/database/models/advertisement.go
+++ b/backend/internal/database/models/advertisement.go
@@ -13,7 +13,7 @@ type Advertisement struct {
 	Title       string                      `json:"title"`
 	Description string                      `json:"description"`
 	Animal      string                      `json:"animal"`
-	Images      datatypes.JSONSlice[string] `gorm:"type:jsonb"`
+	Images      datatypes.JSONSlice[string] `gorm:"type:jsonb" json:"images"`
 }
 
 type PublicAdvertisement struct {


### PR DESCRIPTION
until now we saved every img but didn't check if the same img was returned twice, now we do check for that and save it only once
fixes #133 