### PR TITLE
fix!(backend): change argon2id config

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"github.com/alexedwards/argon2id"
 	"github.com/gofiber/fiber/v2/middleware/compress"
 	"log/slog"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -14,6 +16,8 @@ import . "boschXdaimlerLove/MietMiez/internal/logger"
 var Cfg Config
 
 // The Config contains options to adjust smtp, server, database and minio settings
+//
+//goland:noinspection ALL
 type Config struct {
 	Smtp struct {
 		Host     string `envconfig:"SMTP_HOST"`
@@ -71,5 +75,34 @@ func SetupConfig() {
 func GetCompressionConfig() compress.Config {
 	return compress.Config{
 		Level: compress.LevelBestSpeed,
+	}
+}
+
+// GetArgon2Config config options for argon2id depending on whether the server is running in prod or dev mode
+// values can be generated with $ docker run -it --entrypoint kratos oryd/kratos:v0.5 hashers argon2 calibrate 1s
+func GetArgon2Config() *argon2id.Params {
+	var prodConfig *argon2id.Params
+	var devConfig *argon2id.Params
+
+	prodConfig = &argon2id.Params{
+		Memory:      1048576, // 1GiB
+		Iterations:  1,
+		Parallelism: uint8(runtime.NumCPU()),
+		SaltLength:  16,
+		KeyLength:   32,
+	}
+
+	devConfig = &argon2id.Params{
+		Memory:      64 * 1024,
+		Iterations:  1,
+		Parallelism: uint8(runtime.NumCPU()),
+		SaltLength:  16,
+		KeyLength:   32,
+	}
+
+	if Cfg.Server.Production {
+		return prodConfig
+	} else {
+		return devConfig
 	}
 }

--- a/backend/internal/controllers/user.go
+++ b/backend/internal/controllers/user.go
@@ -23,13 +23,12 @@ func UserCreate(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}
 
-	salt, hash, err := util.HashPassword(user.Hash) // password sent by post request will be mapped to hash field
+	hash, err := util.HashPassword(user.Hash) // password sent by post request will be mapped to hash field
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{})
 	}
 
 	user.Hash = hash
-	user.Salt = salt
 	user.IsActivated = !config.Cfg.Server.EnforceEmailActivation
 
 	dbInstance := database.GetDB()
@@ -111,7 +110,7 @@ func UserLogin(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusLocked)
 	}
 
-	passwordCorrect, err := util.CheckPasswordHash(request.Password, user.Hash, user.Salt)
+	passwordCorrect, err := util.CheckPasswordHash(request.Password, user.Hash)
 	if err != nil {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}
@@ -148,8 +147,7 @@ func UserDelete(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusUnauthorized)
 	}
 
-	// TODO: dead advertisements after user delete
-	Logger.Debug().Any("user", user.ToPublic()).Msg("user deletion")
+	Logger.Trace().Any("user", user.ToPublic()).Msg("user deletion")
 
 	dbInstance := database.GetDB()
 
@@ -289,7 +287,7 @@ func UserResetPassword(c *fiber.Ctx) error {
 
 	Logger.Trace().Interface("resetToken", resetToken).Interface("user", resetToken.User).Msg("Resetting password")
 	user := resetToken.User
-	user.Salt, user.Hash, err = util.HashPassword(request.Password)
+	user.Hash, err = util.HashPassword(request.Password)
 	if err != nil {
 		return err
 	}
@@ -337,7 +335,7 @@ func UserChangePassword(c *fiber.Ctx) error {
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return c.SendStatus(fiber.StatusUnauthorized)
 	}
-	passwordCorrect, err := util.CheckPasswordHash(request.OldPassword, user.Hash, user.Salt)
+	passwordCorrect, err := util.CheckPasswordHash(request.OldPassword, user.Hash)
 	if err != nil {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}
@@ -345,7 +343,7 @@ func UserChangePassword(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusUnauthorized)
 	}
 
-	user.Salt, user.Hash, err = util.HashPassword(request.NewPassword)
+	user.Hash, err = util.HashPassword(request.NewPassword)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/util/hashing.go
+++ b/backend/internal/util/hashing.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"boschXdaimlerLove/MietMiez/internal/config"
 	"crypto/rand"
 	"encoding/base64"
 	"github.com/alexedwards/argon2id"
@@ -9,22 +10,21 @@ import (
 import . "boschXdaimlerLove/MietMiez/internal/logger"
 
 // HashPassword returns salt, hash, error
-func HashPassword(password string) (string, string, error) {
-	salt := GetRandomText(32) // 26 char text
-	hash, err := argon2id.CreateHash(password+salt, argon2id.DefaultParams)
+func HashPassword(password string) (string, error) {
+	hash, err := argon2id.CreateHash(password, config.GetArgon2Config())
 	if err != nil {
 		Logger.Err(err).Msg("Error calculating hash")
-		return "", "", err
+		return "", err
 	}
 
-	return salt, hash, nil
+	return hash, nil
 }
 
-func CheckPasswordHash(password string, hash string, salt string) (bool, error) {
-	match, err := argon2id.ComparePasswordAndHash(password+salt, hash)
+func CheckPasswordHash(password string, hash string) (bool, error) {
+	match, err := argon2id.ComparePasswordAndHash(password, hash)
 	if err != nil {
 
-		Logger.Err(err).Str("hash", hash).Str("password", password).Str("Salt", salt).Msg("Error comparing hash")
+		Logger.Err(err).Str("hash", hash).Str("password", password).Msg("Error comparing hash")
 		return false, err
 	}
 	return match, nil


### PR DESCRIPTION
till now we used default parameters which are for development puposes only I generated a config for our production server which is more secure and consumes more memory during hash generation